### PR TITLE
Fix some bug for my use with ruby 2.3.3

### DIFF
--- a/lib/pry-reload/commands.rb
+++ b/lib/pry-reload/commands.rb
@@ -1,7 +1,9 @@
-Pry.hooks.add_hook(:before_session, "reload-init") do
+require 'pry'
+
+Pry.hooks.add_hook(:before_session, 'reload-init') do
   PryReload::Watch.instance
 end
 
-Pry::Commands.block_command "reload!", "Reload changed files since the session started" do 
+Pry::Commands.block_command 'reload!', 'Reload changed files since the session started' do
   PryReload::Watch.instance.reload!(output)
 end

--- a/lib/pry-reload/watch.rb
+++ b/lib/pry-reload/watch.rb
@@ -1,5 +1,5 @@
-require "rb-inotify"
-require "thread"
+require 'rb-inotify'
+require 'thread'
 
 class PryReload
   class Watch
@@ -15,36 +15,36 @@ class PryReload
     end
 
     def dirs
-      Dir.glob("**/*/");
+      Dir.glob('**/*/')
     end
 
     def process_event(evt)
       if File.directory?(evt.absolute_name)
         evt.notifier.watch(evt.absolute_name)
-      elsif evt.absolute_name.end_with?(".rb")
+      elsif evt.absolute_name.end_with?('.rb')
         @@mutex.synchronize { @modified << evt.absolute_name }
-        #puts "modified #{evt.absolute_name}"
+        # puts "modified #{evt.absolute_name}"
       end
     end
 
     def setup
       dirs.each do |dir|
-        #puts "Listening #{dir}"
+        # puts "Listening #{dir}"
         @notifier.watch(dir, :modify, &Proc.new { |evt| process_event(evt) })
       end
     end
 
     def process
       @thread ||= Thread.new do
-        #puts "Running!"
+        # puts "Running!"
         @notifier.run
       end
     end
 
     def reload!(output)
       @@mutex.synchronize do
-        if @modified.size == 0
-          output.puts "Nothing changed!"
+        if @modified.zero?
+          output.puts 'Nothing changed!'
         else
           changed = @modified.dup.uniq
           @modified = []

--- a/lib/pry-reload/watch.rb
+++ b/lib/pry-reload/watch.rb
@@ -1,5 +1,6 @@
 require 'rb-inotify'
 require 'thread'
+require 'singleton'
 
 class PryReload
   class Watch

--- a/lib/pry-reload/watch.rb
+++ b/lib/pry-reload/watch.rb
@@ -16,7 +16,7 @@ class PryReload
     end
 
     def dirs
-      Dir.glob('**/*/')
+      Dir.glob(['**/', '.'])
     end
 
     def process_event(evt)
@@ -44,7 +44,7 @@ class PryReload
 
     def reload!(output)
       @@mutex.synchronize do
-        if @modified.zero?
+        if @modified.length.zero?
           output.puts 'Nothing changed!'
         else
           changed = @modified.dup.uniq


### PR DESCRIPTION
1. When use with 2.3.3, if not include singleton first, we got following error

```sh
/home/zw963/Dropbox/common/ruby/pry/pry-reload/watch.rb:6:in `<class:Watch>': uninitialized constant PryReload::Watch::Singleton (NameError)
```

2. I think we need monitor current directory too.

3. we should require pry explitly